### PR TITLE
test: Fix initial test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-## [Unreleased]
-
-## [0.1.0] - 2025-04-20
-
-- Initial release

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ruby](https://github.com/serverkit/serverkit-mise/actions/workflows/main.yml/badge.svg)](https://github.com/serverkit/serverkit-mise/actions/workflows/main.yml)
+
 # Serverkit::Mise
 
 TODO: Delete this and the text below, and describe your gem

--- a/serverkit-mise.gemspec
+++ b/serverkit-mise.gemspec
@@ -8,17 +8,15 @@ Gem::Specification.new do |spec|
   spec.authors = ["toshimaru"]
   spec.email = ["me@toshimaru.net"]
 
-  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description = "TODO: Write a longer description or delete this line."
-  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.summary = "Serverkit plug-in for mise."
+  spec.description = "Serverkit plug-in for mise."
+  spec.homepage = "https://github.com/serverkit/serverkit-mise"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.1.0"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/serverkit/serverkit-mise"
+  spec.metadata["changelog_uri"] = "https://github.com/serverkit/serverkit-mise/releases"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/test/serverkit/test_mise.rb
+++ b/test/serverkit/test_mise.rb
@@ -6,8 +6,4 @@ class Serverkit::TestMise < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Serverkit::Mise::VERSION
   end
-
-  def test_it_does_something_useful
-    assert false
-  end
 end


### PR DESCRIPTION
This pull request introduces several updates to improve the documentation, metadata, and testing for the `serverkit-mise` gem. The most significant changes include refining the gem specification, adding a build status badge to the `README.md`, and cleaning up unused or placeholder content in the codebase.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R2): Added a Ruby build status badge linking to the GitHub Actions workflow.

### Metadata Improvements:
* [`serverkit-mise.gemspec`](diffhunk://#diff-eaa700f99ccf66729cbfac1f04d2088b8144fdc5cbb21352fd4d069d93d74cbfL11-R19): Updated the gem specification with a proper summary, description, homepage URL, and metadata links (e.g., source code and changelog URIs). Removed placeholder metadata fields like `allowed_push_host`.

### Codebase Cleanup:
* [`test/serverkit/test_mise.rb`](diffhunk://#diff-8b682292ccf4eb797a07fde76f5635a1726157affc6fc9e77532fd835644da52L9-L12): Removed an unused test method (`test_it_does_something_useful`) that contained placeholder content.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-L5): Removed the placeholder changelog content, including an empty "Unreleased" section.