### PR TITLE
feat: Add `global` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Test](https://github.com/serverkit/serverkit-mise/actions/workflows/test.yml/badge.svg)](https://github.com/serverkit/serverkit-mise/actions/workflows/test.yml)
+[![Gem Version](https://badge.fury.io/rb/serverkit-mise.svg)](https://badge.fury.io/rb/serverkit-mise)
 
 # serverkit-mise
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,9 @@
 
 ## Installation
 
-Install the gem and add to the application's Gemfile by executing:
-
-```bash
-bundle add serverkit-mise
-```
-
-If bundler is not being used to manage dependencies, install the gem by executing:
-
-```bash
-gem install serverkit-mise
+```rb
+# Gemfile
+gem "serverkit-mise"
 ```
 
 ## Usage
@@ -52,7 +45,8 @@ Install specified tool and add the version to `mise.yml`.
 #### Attributes
 
 - `name` - tool name (required)
-- `version` - tool version (optional)
+- `version` - tool version (optional, if not specified, the latest version will be installed)
+- `global` - global option (optional, default: `true`)
 
 #### Example
 
@@ -61,6 +55,7 @@ resources:
   - type: mise_use
     name: go
     version: '1.23'
+    global: false
   - type: mise_use
     name: ruby
 ```

--- a/lib/serverkit/resources/mise_use.rb
+++ b/lib/serverkit/resources/mise_use.rb
@@ -7,18 +7,17 @@ module Serverkit
     class MiseUse < Base
       attribute :name, required: true, type: String
       attribute :version, type: String
-      # FIXME: add global option
-      attribute :global, type: [TrueClass, FalseClass] # , default: true
+      attribute :global, type: [TrueClass, FalseClass], default: true
 
       # @note Override
       def apply
-        run_command("mise use --global #{name_with_version}")
+        run_command("mise use #{global_option} #{name_with_version}")
       end
 
       # @note Override
       def check
         cmd = if global
-          "mise ls --global  #{name} | grep '#{version_or_latest}'"
+          "mise ls --cd $HOME #{name} | grep '#{version_or_latest}'"
         else
           "mise ls --current #{name} | grep '#{version_or_latest}'"
         end
@@ -42,13 +41,14 @@ module Serverkit
         end
       end
 
+      # @return [String]
       def version_or_latest
         version || "latest"
       end
 
-      # def global_option
-      #   "--global" if global
-      # end
+      def global_option
+        "--global" if global
+      end
     end
   end
 end


### PR DESCRIPTION
## Setting

```yml
  - type: mise_use
    global: false
    name: ruby
    version: '3.3'
  - type: mise_use
    name: ruby
    global: true
```

## Result

```console
$ bundle exec serverkit apply serverkit.yml.erb --log-level=DEBUG
...
Running mise ls --current ruby | grep '3.3' on localhost
ruby  3.3.8  ~/src/github.com/toshimaru/dotfiles/mise.toml  3.3
Finished with 0 on localhost
[SKIP] mise_use ruby on localhost
Running mise ls --cd $HOME ruby | grep 'latest' on localhost
ruby  3.4.3  ~/.config/mise/config.toml  latest
Finished with 0 on localhost
[SKIP] mise_use ruby on localhost
``` 