### PR TITLE
fix: Grep version with version prefix

### DIFF
--- a/lib/serverkit/resources/mise_install.rb
+++ b/lib/serverkit/resources/mise_install.rb
@@ -15,7 +15,7 @@ module Serverkit
 
       # @note Override
       def check
-        check_command(" mise ls #{name} | grep '#{version_or_latest}'")
+        check_command("mise ls #{name} | grep '\\s#{version_or_latest}'")
       end
 
       private


### PR DESCRIPTION
grep version with version prefix.

```
[SKIP] mise_use node on localhost
Running mise ls yarn | grep '\s1' on localhost
yarn  1.22.22
```

- install yarn@1
  - 🙅‍♂️ yarn  4.2.**1** (patch version matched)
  - 🙆‍♂️ yarn  **1**.22.1 (major version matched)