### PR TITLE
fix: Fix latest version check command

### DIFF
--- a/lib/serverkit/resources/mise_install.rb
+++ b/lib/serverkit/resources/mise_install.rb
@@ -15,7 +15,12 @@ module Serverkit
 
       # @note Override
       def check
-        check_command("mise ls #{name} | grep '\\s#{version_or_latest}'")
+        cmd = if version
+          "mise ls #{name} | grep '\\s#{version}'"
+        else
+          "mise ls #{name} | grep \"$(mise latest #{name})\""
+        end
+        check_command(cmd)
       end
 
       private
@@ -33,11 +38,6 @@ module Serverkit
         else
           name
         end
-      end
-
-      # @return [String]
-      def version_or_latest
-        version || "latest"
       end
     end
   end


### PR DESCRIPTION
grep latest version using `mise latest name`.

`mise install yarn`:

```yml
  - type: mise_install
    name: yarn
```

```console
2025-05-06 17:38:41 (9.14 MB/s) - 'yarn' saved [3010104]
mise yarn@4.9.1    ✓ installed
Finished with 0 on localhost
Running mise ls yarn | grep "$(mise latest yarn)" on localhost
yarn  4.9.1
Finished with 0 on localhost
[DONE] mise_install yarn on localhost
```